### PR TITLE
Sprite Update Fix

### DIFF
--- a/src/common/PkmImage/PkmImage.tsx
+++ b/src/common/PkmImage/PkmImage.tsx
@@ -32,18 +32,16 @@ const PkmImage = ({ dexNum, form, name, shiny = false }: PkmImageProps) => {
   };
 
   useEffect(() => {
-    loadImage(imgSrc)
+    loadImage(baseImgSrc + getImage(dexNum, form))
+      .then((src) => {
+        setImgSrc(src as string);
+      })
       .catch((error) => {
         console.error(error);
         setImgSrc(baseImgSrc + getImage(dexNum, 0));
-      })
-      .then((src) => {
-        if (src !== imgSrc) {
-          setImgSrc(src as string);
-        }
       });
-  }, [dexNum, form, name, shiny, imgSrc]);
-
+  }, [dexNum, form, name, shiny]);
+  
   return (
     <div
       className={`pkm ${shiny ? 'shiny' : ''}`}

--- a/src/components/Calculator/elements/PokemonSlot/PokemonSlot.module.scss
+++ b/src/components/Calculator/elements/PokemonSlot/PokemonSlot.module.scss
@@ -14,8 +14,9 @@
     .image {
       display: flex;
       align-items: center;
+      margin-left: 15px;
       justify-content: center;
-      height: 3.5rem;
+      height: 4.5rem;
       width: 4.5rem;
     }
   }


### PR DESCRIPTION
# Description

This is a fix to the Sprite Loading error. Apparently the images needed to be loaded in the reverse order for it to be updated correctly. This also indirectly fixed another bug that was present that didn't show the form 0 of the mons that don't have forms

Fixes # 15
